### PR TITLE
Add landing/about/contact pages and tests

### DIFF
--- a/__tests__/components/pages/About.test.tsx
+++ b/__tests__/components/pages/About.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import About from '@/components/pages/About';
+import { ThemeProvider } from '@/providers/ThemeContext';
+
+vi.mock('@/components/templates', () => ({
+  MainLayout: vi.fn(({ children }) => <div data-testid="main-layout">{children}</div>),
+  SectionLayout: vi.fn(({ children, title, subtitle, centered }) => (
+    <div data-testid="section-layout" data-centered={centered?.toString()}>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {children}
+    </div>
+  ))
+}));
+
+vi.mock('@/components/atoms', () => ({
+  ProfileImage: () => <div data-testid="profile-image" />
+}));
+
+describe('About Page Component', () => {
+  beforeEach(() => {
+    render(
+      <ThemeProvider>
+        <About />
+      </ThemeProvider>
+    );
+  });
+
+  it('renders main layout and section layout', () => {
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument();
+    const section = screen.getByTestId('section-layout');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute('data-centered', 'true');
+  });
+
+  it('displays page title and subtitle', () => {
+    expect(screen.getByText('About Eterna Design')).toBeInTheDocument();
+    expect(screen.getByText('Crafting thoughtful digital experiences')).toBeInTheDocument();
+  });
+
+  it('shows profile image', () => {
+    expect(screen.getByTestId('profile-image')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/pages/Landing.test.tsx
+++ b/__tests__/components/pages/Landing.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Landing from '@/components/pages/Landing';
+import { ThemeProvider } from '@/providers/ThemeContext';
+
+vi.mock('@/components/templates', () => ({
+  MainLayout: vi.fn(({ children }) => <div data-testid="main-layout">{children}</div>),
+  SectionLayout: vi.fn(({ children, title }) => (
+    <div data-testid="section-layout">
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ))
+}));
+
+vi.mock('@/components/organisms', () => ({
+  Hero: () => <div data-testid="hero" />
+}));
+
+vi.mock('@/components/atoms', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span data-testid="badge">{children}</span>
+}));
+
+describe('Landing Page Component', () => {
+  it('renders hero and feature badges', () => {
+    render(
+      <ThemeProvider>
+        <Landing />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument();
+    expect(screen.getByTestId('hero')).toBeInTheDocument();
+    const badges = screen.getAllByTestId('badge');
+    expect(badges).toHaveLength(3);
+  });
+});

--- a/__tests__/components/pages/Shop.test.tsx
+++ b/__tests__/components/pages/Shop.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Shop from '@/components/pages/Shop';
+import { ThemeProvider } from '@/providers/ThemeContext';
+
+
+vi.mock('@/components/organisms', () => ({
+  ShopItemCard: ({ item }: { item: { name: string } }) => <div data-testid="item">{item.name}</div>
+}));
+
+vi.mock('@/components/templates', () => ({
+  MainLayout: vi.fn(({ children }) => <div data-testid="main-layout">{children}</div>),
+  SectionLayout: vi.fn(({ children, title }) => (
+    <div data-testid="section-layout">
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ))
+}));
+
+describe('Shop Page Component', () => {
+  it('renders products from data file', async () => {
+    const element = await Shop();
+    render(<ThemeProvider>{element}</ThemeProvider>);
+
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument();
+    expect(screen.getByText('Shop')).toBeInTheDocument();
+    const items = screen.getAllByTestId('item');
+    expect(items.length).toBeGreaterThan(0);
+  });
+});

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,5 @@
+import { About } from '@/components/pages';
+
+export default function AboutPage() {
+  return <About />;
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,5 @@
+import { Contact } from '@/components/pages';
+
+export default function ContactPage() {
+  return <Contact />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,7 @@
 'use client';
 import React from 'react';
-import { Navbar, Hero } from '@/components/organisms';
+import { Landing } from '@/components/pages';
 
 export default function Home() {
-  return (
-    <div className="flex flex-col min-h-screen font-[family-name:var(--font-geist-sans)]">
-      <header className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700">
-        <Navbar className="w-full" />
-      </header>
-      <main className="flex-grow flex items-center justify-center">
-        <Hero
-          title="Eterna Design"
-          subtitle="Creative solutions for your brand"
-          ctaText="Request a Quote"
-          ctaLink="/commission"
-        />
-      </main>
-      <footer className="flex items-center justify-center py-4">
-        <p className="text-xs text-gray-500 dark:text-gray-400">© {new Date().getFullYear()} Eterna Design</p>
-      </footer>
-    </div>
-  );
+  return <Landing />;
 }

--- a/components/atoms/index.ts
+++ b/components/atoms/index.ts
@@ -5,4 +5,5 @@ export { default as IconLink } from './IconLink';
 export { default as Input } from './Input';
 export { default as Logo } from './Logo';
 export { default as ProfileImage } from './ProfileImage';
+export { default as Badge } from './Badge';
 export * from './icons'; // Export all icons

--- a/components/pages/About.tsx
+++ b/components/pages/About.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MainLayout, SectionLayout } from '@/components/templates';
+import { ProfileImage } from '@/components/atoms';
+
+export default function About() {
+  return (
+    <MainLayout>
+      <SectionLayout
+        title="About Eterna Design"
+        subtitle="Crafting thoughtful digital experiences"
+        centered
+      >
+        <div className="flex flex-col items-center space-y-6 max-w-2xl">
+          <ProfileImage
+            src="/images/logo-ani-0.jpeg"
+            alt="Eterna Design"
+            size="lg"
+            priority
+          />
+          <p className="text-lg text-gray-600 dark:text-gray-300 text-center">
+            Eterna Design is a creative studio specializing in branding, web
+            design and illustration. We focus on delivering clean, modern
+            solutions that elevate your brand.
+          </p>
+        </div>
+      </SectionLayout>
+    </MainLayout>
+  );
+}

--- a/components/pages/Landing.tsx
+++ b/components/pages/Landing.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Hero } from '@/components/organisms';
+import { MainLayout, SectionLayout } from '@/components/templates';
+import { Badge } from '@/components/atoms';
+
+export default function Landing() {
+  return (
+    <MainLayout>
+      <Hero
+        title="Eterna Design"
+        subtitle="Creative solutions for your brand"
+        ctaText="Request a Quote"
+        ctaLink="/commission"
+      />
+      <SectionLayout
+        title="What We Offer"
+        subtitle="A full range of design services"
+        centered
+      >
+        <div className="flex flex-wrap justify-center gap-4">
+          <Badge>Brand Identity</Badge>
+          <Badge>Web Design</Badge>
+          <Badge>Illustration</Badge>
+        </div>
+      </SectionLayout>
+    </MainLayout>
+  );
+}

--- a/components/pages/index.ts
+++ b/components/pages/index.ts
@@ -2,3 +2,5 @@
 export { default as Contact } from './Contact';
 export { default as Commission } from './Commission';
 export { default as Shop } from './Shop';
+export { default as About } from './About';
+export { default as Landing } from './Landing';


### PR DESCRIPTION
## Summary
- implement new `Landing` and `About` page components
- wire new routes for `/about` and `/contact`
- expose `Landing` and `About` via page index
- export `Badge` from atom index
- refactor home page to use new landing component
- add unit tests for Landing, About and Shop pages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad055211c8324a0bc7154e71457a2